### PR TITLE
Fix major email sending-bug.

### DIFF
--- a/app/model/mixPayload.py
+++ b/app/model/mixPayload.py
@@ -46,12 +46,14 @@ class ParsedMixPayload:
         
         self.DecryptedData = self.DecryptedData[0 : self.DataLength + 4]
         
+        self.DestinationFields = []
         self.NumDestinationFields = struct.unpack('B', self.DecryptedData[byteIndex])[0]
         byteIndex += 1
         for i in range(self.NumDestinationFields):
             self.DestinationFields.append(self.DecryptedData[byteIndex : byteIndex + 80].strip(chr(0)).strip())
             byteIndex += 80
         
+        self.HeaderFields = []
         self.NumHeaderFields = struct.unpack('B', self.DecryptedData[4])[0]
         byteIndex += 1
         for i in range(self.NumDestinationFields):


### PR DESCRIPTION
Without emptying the array in the instance variable, the class uses the static variable. Destinations keep getting appended to the end of the array, and messages get sent to all the addresses seen so far.  Quite
bad.  The same would happen for headers.
